### PR TITLE
Fix lint checking and misc improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .DS_Store
 .env
 .clone
+.crate-docs-build
 *.lint

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,18 @@ Changes
 Unreleased
 ==========
 
+- Improved output by muting some Make rules
+- Removed `_no_vale` file from `docs`, which enables Vale testing using local
+  test Sphinx project
+- Changed `.clone` directory to `.crate-docs-build`, which should be more
+  readily understandable for most users
+- Improved lint checking output
+- Forced a full lint check every time `make dev` or `make check` is run
+- Fixed issue with `lint-watch` target not working the first time you run `make
+  dev`
+- Fixed issue with `bin/lint` not being run via fswatch
+- Moved lint files to hidden subdirectory to avoid cluttering the visible file
+  tree in text editors
 - Renamed project to crate-docs-build
 
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,19 +18,16 @@
 # pursuant to the terms of the relevant commercial agreement.
 
 
-# `TOP_DIR` is the top-level directory of the repository
-export TOP_DIR  := ..
-
-# `DOCS_DIR` is the path to `docs` from `TOP_DIR`
-export DOCS_DIR := docs
-
-
 # Do not edit anything below this line
 ###############################################################################
 
+.EXPORT_ALL_VARIABLES:
+
+DOCS_DIR      := docs
+TOP_DIR       := ..
 BUILD_JSON    := build.json
 BUILD_REPO    := https://github.com/crate/crate-docs-build.git
-CLONE_DIR     := .clone
+CLONE_DIR     := .crate-docs-build
 SRC_DIR       := $(CLONE_DIR)/src
 SELF_SRC      := $(TOP_DIR)/src
 SELF_MAKEFILE := $(SELF_SRC)/rules.mk
@@ -46,7 +43,7 @@ endif
 
 # Default rule
 .PHONY: help
-help: $(SRC_DIR)
+help: $(CLONE_DIR)
 	@ $(SRC_MAKE) $@
 
 ifneq ($(wildcard $(SELF_MAKEFILE)),)
@@ -54,9 +51,7 @@ ifneq ($(wildcard $(SELF_MAKEFILE)),)
 # so that it can test itself
 $(CLONE_DIR):
 	mkdir -p $@
-
-$(SRC_DIR): $(CLONE_DIR)
-	cp -R $(SELF_SRC) $@
+	cp -R $(SELF_SRC) $(SRC_DIR)
 else
 # All other projects install a versioned copy of the core build rules
 $(CLONE_DIR):
@@ -70,7 +65,7 @@ Makefile:
 
 # By default, pass targets through to the core build rules
 .PHONY:
-%: $(SRC_DIR)
+%: $(CLONE_DIR)
 	@ $(SRC_MAKE) $@
 
 .PHONY: reset

--- a/src/bin/lint
+++ b/src/bin/lint
@@ -19,6 +19,7 @@
 # these terms will supersede the license and you may use the software solely
 # pursuant to the terms of the relevant commercial agreement.
 
+
 if test ! -n "$VALE"; then
     echo '`VALE` is not set.'
     exit 1
@@ -30,27 +31,13 @@ if test ! -n "$VALE_OPTS"; then
 fi
 
 SOURCE_FILE=$1
-LINT_FILE=$SOURCE_FILE.lint
+LINT_FILE=$2
 
-run_log () {
-    TMP_FILE=`mktemp /tmp/lint.XXXXXXXXXX` || exit 1
-    append_to_log () {
-        cat $TMP_FILE | tee -a $LINT_FILE
-    }
-    if $@ > $TMP_FILE; then
-        append_to_log
-    else
-        append_to_log
-        # Touch source files when the lint fails so they get picked up by Make
-        # for linting again
-        sleep 1 && touch $SOURCE_FILE
-        exit 1
-    fi
-}
+echo "Linting: $SOURCE_FILE"
+printf '%0.s-' {1..81}
+echo
+$VALE $VALE_OPTS $SOURCE_FILE
+echo
+echo
 
-printf "Linting: \033[35m$SOURCE_FILE\033[00m\n"
-
-echo '# Vale' > $LINT_FILE
-printf '%0.s#' {1..79} >> $LINT_FILE
-echo >> $LINT_FILE
-run_log $VALE $VALE_OPTS $SOURCE_FILE
+touch $LINT_FILE


### PR DESCRIPTION
- Improved output by muting some Make rules
- Removed `_no_vale` file from `docs`, which enables Vale testing using local
  test Sphinx project
- Changed `.clone` directory to `.crate-docs-build`, which should be more
  readily understandable for most users
- Improved lint checking output
- Forced a full lint check every time `make dev` or `make check` is run
- Fixed issue with `lint-watch` target not working the first time you run `make
  dev`
- Fixed issue with `bin/lint` not being run via fswatch (fixes #1)
- Moved lint files to hidden subdirectory to avoid cluttering the visible file
  tree in text editors (fixes #20)
